### PR TITLE
Keytool.sign: Print the signed message as an hex string

### DIFF
--- a/tools/source/key/main.d
+++ b/tools/source/key/main.d
@@ -75,7 +75,7 @@ int main (string[] args)
             scope ret = kp.address.verify(res);
             assert(ret == msg);
         }
-        writeln("Signed message: ", res);
+        writeln("Signed message: ", toHexString(res));
         break;
 
     case "verify":
@@ -94,7 +94,7 @@ int main (string[] args)
             writeln("Verification failed");
             return 1;
         }
-        writeln("Result: ", result);
+        writeln("Result: ", toHexString(result));
         if (result.all!((ubyte c) => char(c).isASCII))
             writeln("Result as string: ", cast(const(char)[])result);
         break;

--- a/tools/source/key/main.d
+++ b/tools/source/key/main.d
@@ -96,7 +96,7 @@ int main (string[] args)
         }
         writeln("Result: ", toHexString(result));
         if (result.all!((ubyte c) => char(c).isASCII))
-            writeln("Result as string: ", cast(const(char)[])result);
+            writeln("Result as string: \"", cast(const(char)[])result, '"');
         break;
 
     default:


### PR DESCRIPTION
CC @TrustHenry : Now the result are symmetric:

```
./bin/keytool sign SCMURBUOY76KQK6MUAIU47XVKJG3H7P5O6HOLVVOOGO57KIJJIHSLE4N "Henry is handsome."
Signed message: cae0b2b7168e8aef88a45eb2f433068a61c50c044aaf9e88de161026a461f73a95201e6b5fafe2ec0464ccd5fb6197007a21491381f0975456971dbafe39000348656e72792069732068616e64736f6d652e
```

```
./bin/keytool verify GD2MCBTM6JKDU6AONX2RLWG46HQGWBF32OIDVHKF4UCZC2SEBS36FYUM cae0b2b7168e8aef88a45eb2f433068a61c50c044aaf9e88de161026a461f73a95201e6b5fafe2ec0464ccd5fb6197007a21491381f0975456971dbafe39000348656e72792069732068616e64736f6d652e
Result: [72, 101, 110, 114, 121, 32, 105, 115, 32, 104, 97, 110, 100, 115, 111, 109, 101, 46]
Result as string: Henry is handsome.
```